### PR TITLE
Support `execute_command` option

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,6 @@
-source 'https://rubygems.org'
+# frozen_string_literal: true
+
+source "https://rubygems.org"
 
 # Specify your gem's dependencies in danger-iblinter.gemspec
 gemspec

--- a/Guardfile
+++ b/Guardfile
@@ -1,10 +1,12 @@
+# frozen_string_literal: true
+
 # A guardfile for making Danger Plugins
 # For more info see https://github.com/guard/guard#readme
 
 # To run, use `bundle exec guard`.
 
-guard :rspec, cmd: 'bundle exec rspec' do
-  require 'guard/rspec/dsl'
+guard :rspec, cmd: "bundle exec rspec" do
+  require "guard/rspec/dsl"
   dsl = Guard::RSpec::Dsl.new(self)
 
   # RSpec files

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ This plugin requires `iblinter` executable binary.
 
 ```ruby
 iblinter.binary_path = "./Pods/IBLinter/bin/iblinter"
+iblinter.execute_command = "swift run iblinter"
 iblinter.lint("./path/to/project", fail_on_warning: true, inline_mode: true)
 ```
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,10 @@ This plugin requires `iblinter` executable binary.
 
 ```ruby
 iblinter.binary_path = "./Pods/IBLinter/bin/iblinter"
+iblinter.lint("./path/to/project", fail_on_warning: true, inline_mode: true)
+```
+
+```ruby
 iblinter.execute_command = "swift run iblinter"
 iblinter.lint("./path/to/project", fail_on_warning: true, inline_mode: true)
 ```

--- a/Rakefile
+++ b/Rakefile
@@ -1,23 +1,25 @@
-require 'bundler/gem_tasks'
-require 'rspec/core/rake_task'
-require 'rubocop/rake_task'
+# frozen_string_literal: true
+
+require "bundler/gem_tasks"
+require "rspec/core/rake_task"
+require "rubocop/rake_task"
 
 RSpec::Core::RakeTask.new(:specs)
 
 task default: :specs
 
 task :spec do
-  Rake::Task['specs'].invoke
-  Rake::Task['rubocop'].invoke
-  Rake::Task['spec_docs'].invoke
+  Rake::Task["specs"].invoke
+  Rake::Task["rubocop"].invoke
+  Rake::Task["spec_docs"].invoke
 end
 
-desc 'Run RuboCop on the lib/specs directory'
+desc "Run RuboCop on the lib/specs directory"
 RuboCop::RakeTask.new(:rubocop) do |task|
-  task.patterns = ['lib/**/*.rb', 'spec/**/*.rb']
+  task.patterns = ["lib/**/*.rb", "spec/**/*.rb"]
 end
 
-desc 'Ensure that the plugin passes `danger plugins lint`'
+desc "Ensure that the plugin passes `danger plugins lint`"
 task :spec_docs do
-  sh 'bundle exec danger plugins lint'
+  sh "bundle exec danger plugins lint"
 end

--- a/danger-iblinter.gemspec
+++ b/danger-iblinter.gemspec
@@ -1,42 +1,43 @@
-# coding: utf-8
-lib = File.expand_path('../lib', __FILE__)
+# frozen_string_literal: true
+
+lib = File.expand_path("lib", __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
-require 'iblinter/gem_version.rb'
+require "iblinter/gem_version.rb"
 
 Gem::Specification.new do |spec|
-  spec.name          = 'danger-iblinter'
+  spec.name          = "danger-iblinter"
   spec.version       = Iblinter::VERSION
-  spec.authors       = ['Yuta Saito']
-  spec.email         = ['kateinoigakukun@gmail.com']
-  spec.description   = %q{A danger plugin for linting Interface Builder files with IBLinter.}
-  spec.summary       = %q{A danger plugin for linting Interface Builder files with IBLinter.}
-  spec.homepage      = 'https://github.com/IBDecodable/danger-ruby-iblinter'
-  spec.license       = 'MIT'
+  spec.authors       = ["Yuta Saito"]
+  spec.email         = ["kateinoigakukun@gmail.com"]
+  spec.description   = "A danger plugin for linting Interface Builder files with IBLinter."
+  spec.summary       = "A danger plugin for linting Interface Builder files with IBLinter."
+  spec.homepage      = "https://github.com/IBDecodable/danger-ruby-iblinter"
+  spec.license       = "MIT"
 
   spec.files         = `git ls-files`.split($/)
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
-  spec.require_paths = ['lib']
+  spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency 'danger-plugin-api', '~> 1.0'
+  spec.add_runtime_dependency "danger-plugin-api", "~> 1.0"
 
   # General ruby development
-  spec.add_development_dependency 'bundler', '~> 1.3'
-  spec.add_development_dependency 'rake', '~> 10.0'
+  spec.add_development_dependency "bundler", "~> 1.3"
+  spec.add_development_dependency "rake", "~> 10.0"
 
   # Testing support
-  spec.add_development_dependency 'rspec', '~> 3.4'
+  spec.add_development_dependency "rspec", "~> 3.4"
 
   # Linting code and docs
   spec.add_development_dependency "rubocop"
   spec.add_development_dependency "yard"
 
   # Makes testing easy via `bundle exec guard`
-  spec.add_development_dependency 'guard', '~> 2.14'
-  spec.add_development_dependency 'guard-rspec', '~> 4.7'
+  spec.add_development_dependency "guard", "~> 2.14"
+  spec.add_development_dependency "guard-rspec", "~> 4.7"
 
   # If you want to work on older builds of ruby
-  spec.add_development_dependency 'listen', '3.0.7'
+  spec.add_development_dependency "listen", "3.0.7"
 
   # This gives you the chance to run a REPL inside your tests
   # via:
@@ -45,5 +46,5 @@ Gem::Specification.new do |spec|
   #    binding.pry
   #
   # This will stop test execution and let you inspect the results
-  spec.add_development_dependency 'pry'
+  spec.add_development_dependency "pry"
 end

--- a/lib/iblinter/iblinter.rb
+++ b/lib/iblinter/iblinter.rb
@@ -1,8 +1,9 @@
 # frozen_string_literal: true
 
 class IBLinterRunner
-  def initialize(binary_path)
+  def initialize(binary_path, execute_command)
     @binary_path = binary_path
+    @execute_command = execute_command
   end
 
   def run(command)
@@ -16,8 +17,9 @@ class IBLinterRunner
   end
 
   def lint_command(options)
-    abs_binary_path = @binary_path.nil? ? "iblinter" : File.absolute_path(@binary_path)
-    "#{abs_binary_path} lint #{arguments(options.merge(reporter: 'json'))}"
+    executable = @execute_command
+    executable ||= @binary_path.nil? ? "iblinter" : File.absolute_path(@binary_path)
+    "#{executable} lint #{arguments(options.merge(reporter: 'json'))}"
   end
 
   # Parse options into shell arguments.

--- a/lib/iblinter/plugin.rb
+++ b/lib/iblinter/plugin.rb
@@ -18,6 +18,7 @@ module Danger
     # The path to IBLinter"s execution
     # @return  [void]
     attr_accessor :binary_path
+    attr_accessor :execute_command
 
     # Lints IB files. Will fail if `iblinter` cannot be installed correctly.
     # @return   [void]
@@ -51,7 +52,7 @@ module Danger
     # Instantiate iblinter
     # @return     [IBLinterRunner]
     def iblinter
-      IBLinterRunner.new(@binary_path)
+      IBLinterRunner.new(@binary_path, @execute_command)
     end
 
     private
@@ -59,6 +60,9 @@ module Danger
     def iblinter_installed?
       if !@binary_path.nil? && File.exist?(@binary_path)
         return true
+      end
+      if !@execute_command.nil? && `#{@execute_command}`.include?("not found")
+        return false
       end
 
       !`which iblinter`.empty?

--- a/lib/iblinter/plugin.rb
+++ b/lib/iblinter/plugin.rb
@@ -62,11 +62,6 @@ module Danger
         return true
       end
 
-      unless @execute_command.nil?
-        system(@execute_command)
-        return $? == 0
-      end
-
       !`which iblinter`.empty?
     end
 

--- a/lib/iblinter/plugin.rb
+++ b/lib/iblinter/plugin.rb
@@ -24,7 +24,7 @@ module Danger
     # @return   [void]
     #
     def lint(path = Dir.pwd, fail_on_warning: false, inline_mode: true, options: {})
-      if !@execute_command && iblinter_installed?
+      unless @execute_command || iblinter_installed?
         raise "iblinter is not installed"
       end
 

--- a/lib/iblinter/plugin.rb
+++ b/lib/iblinter/plugin.rb
@@ -24,7 +24,9 @@ module Danger
     # @return   [void]
     #
     def lint(path = Dir.pwd, fail_on_warning: false, inline_mode: true, options: {})
-      raise "iblinter is not installed" unless iblinter_installed?
+      if !@execute_command && iblinter_installed?
+        raise "iblinter is not installed"
+      end
 
       issues = iblinter.lint(path, options)
       return if issues.empty?

--- a/lib/iblinter/plugin.rb
+++ b/lib/iblinter/plugin.rb
@@ -61,8 +61,10 @@ module Danger
       if !@binary_path.nil? && File.exist?(@binary_path)
         return true
       end
-      if !@execute_command.nil? && `#{@execute_command}`.include?("not found")
-        return false
+
+      unless @execute_command.nil?
+        system(@execute_command)
+        return $? == 0
       end
 
       !`which iblinter`.empty?

--- a/spec/iblinter_spec.rb
+++ b/spec/iblinter_spec.rb
@@ -4,11 +4,34 @@ require File.expand_path("spec_helper", __dir__)
 require_relative "../lib/iblinter/iblinter"
 
 describe IBLinterRunner do
-  it "command arguments works" do
-    binary_path = File.absolute_path "path/to/binary"
-    options = {}
-    cmd = "#{binary_path} lint --reporter json"
-    iblinter = IBLinterRunner.new(binary_path)
-    expect(iblinter.lint_command(options)).to eq cmd
+  context "binary_path is passed" do
+    it "should return valid command" do
+      binary_path = File.absolute_path "path/to/binary"
+      options = {}
+      cmd = "#{binary_path} lint --reporter json"
+      iblinter = IBLinterRunner.new(binary_path, nil)
+      expect(iblinter.lint_command(options)).to eq cmd
+    end
+  end
+
+  context "execute_command is passed" do
+    it "should return valid command" do
+      execute_command = "swift run iblinter"
+      options = {}
+      cmd = "swift run iblinter lint --reporter json"
+      iblinter = IBLinterRunner.new(nil, execute_command)
+      expect(iblinter.lint_command(options)).to eq cmd
+    end
+  end
+
+  context "binary_path and execute_command are passed" do
+    it "binary_path should be ignored" do
+      binary_path = File.absolute_path "path/to/binary"
+      execute_command = "swift run iblinter"
+      options = {}
+      cmd = "swift run iblinter lint --reporter json"
+      iblinter = IBLinterRunner.new(binary_path, execute_command)
+      expect(iblinter.lint_command(options)).to eq cmd
+    end
   end
 end

--- a/spec/iblinter_spec.rb
+++ b/spec/iblinter_spec.rb
@@ -4,33 +4,34 @@ require File.expand_path("spec_helper", __dir__)
 require_relative "../lib/iblinter/iblinter"
 
 describe IBLinterRunner do
+  let(:options) { {} }
+  let(:cmd) { "swift run iblinter lint --reporter json" }
+  let(:binary_path) { nil }
+  let(:execute_command) { nil }
+  let(:iblinter) { IBLinterRunner.new(binary_path, execute_command) }
+
   context "binary_path is passed" do
+    let(:binary_path) { File.absolute_path "path/to/binary" }
+    let(:cmd) { "#{binary_path} lint --reporter json" }
+
     it "should return valid command" do
-      binary_path = File.absolute_path "path/to/binary"
-      options = {}
-      cmd = "#{binary_path} lint --reporter json"
-      iblinter = IBLinterRunner.new(binary_path, nil)
       expect(iblinter.lint_command(options)).to eq cmd
     end
   end
 
   context "execute_command is passed" do
+    let(:execute_command) { "swift run iblinter" }
+
     it "should return valid command" do
-      execute_command = "swift run iblinter"
-      options = {}
-      cmd = "swift run iblinter lint --reporter json"
-      iblinter = IBLinterRunner.new(nil, execute_command)
       expect(iblinter.lint_command(options)).to eq cmd
     end
   end
 
   context "binary_path and execute_command are passed" do
-    it "binary_path should be ignored" do
-      binary_path = File.absolute_path "path/to/binary"
-      execute_command = "swift run iblinter"
-      options = {}
-      cmd = "swift run iblinter lint --reporter json"
-      iblinter = IBLinterRunner.new(binary_path, execute_command)
+    let(:execute_command) { "swift run iblinter" }
+    let(:binary_path) { File.absolute_path "path/to/binary" }
+
+    it "should ignore binary_path" do
       expect(iblinter.lint_command(options)).to eq cmd
     end
   end

--- a/spec/plugin_spec.rb
+++ b/spec/plugin_spec.rb
@@ -20,7 +20,7 @@ module Danger
       end
 
       it "inline comment works with relative path" do
-        linter = IBLinterRunner.new("/path/to/binary")
+        linter = IBLinterRunner.new("/path/to/binary", nil)
         allow(linter).to receive(:lint) do
           JSON.parse(File.read(File.dirname(__FILE__) + "/support/fixtures/iblinter.json"))
         end


### PR DESCRIPTION
# Context

I want to use IBLinter installed with SwiftPM or mint.
However, this plugin only accepts binary path.

# Description

I added `execute_command` option to specify the executing command.

```ruby
iblinter.execute_command = "swift run iblinter"
iblinter.lint("./path/to/project", fail_on_warning: true, inline_mode: true)
```

If both `binary_path` and `execute_command` are passed. `binary_path` is ignored.

And I just apply `rubocop -a` ✨ 
